### PR TITLE
Clean up multilingual templates

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,20 +11,14 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About" class="active">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About" class="active">關於課程</a></li>
                 </ul>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
 <div class="lang-switcher">
 <select id="language-select">
 <option value="zh">繁體中文</option>
@@ -109,20 +103,20 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證與謬誤</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接詞與複合陳述句</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理與批判性思考</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證與謬誤</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接詞與複合陳述句</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理與批判性思考</a></li>
                     </ul>
                 </div>
             </div>
@@ -133,7 +127,6 @@
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/courses.html
+++ b/courses.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses" class="active">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses" class="active">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <section class="courses">
-        <div class="container">
             <h1 class="section-title">五天課程內容</h1>
             
             <div class="course-cards">
@@ -145,20 +133,20 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證與謬誤</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接詞與複合陳述句</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理與批判性思考</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證與謬誤</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接詞與複合陳述句</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理與批判性思考</a></li>
                     </ul>
                 </div>
             </div>
@@ -169,7 +157,6 @@
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day1.html
+++ b/day1.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="course-container">
             <aside class="sidebar">
                 <h3 class="sidebar-title">課程導覽</h3>
                 <ul class="sidebar-links">
@@ -216,31 +204,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day1_quiz.html
+++ b/day1_quiz.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="quiz-container">
             <div class="quiz-header">
                 <h1>第一天測驗：邏輯學 (Logic)基礎與語言</h1>
             </div>
@@ -184,31 +172,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day1_slides.html
+++ b/day1_slides.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="slide-container">
             <h1>第一天：邏輯學 (Logic)基礎與語言</h1>
             
             <div class="slide-content">
@@ -191,31 +179,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day2.html
+++ b/day2.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="course-container">
             <aside class="sidebar">
                 <h3 class="sidebar-title">課程導覽</h3>
                 <ul class="sidebar-links">
@@ -293,31 +281,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day2_quiz.html
+++ b/day2_quiz.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="quiz-container">
             <div class="quiz-header">
                 <h1>第二天測驗：論證 (Argument)與謬誤 (Fallacy)</h1>
             </div>
@@ -184,31 +172,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day2_slides.html
+++ b/day2_slides.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="slide-container">
             <h1>第二天：論證 (Argument)與謬誤 (Fallacy)</h1>
             
             <div class="slide-content">
@@ -226,31 +214,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day3.html
+++ b/day3.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="course-container">
             <aside class="sidebar">
                 <h3 class="sidebar-title">課程導覽</h3>
                 <ul class="sidebar-links">
@@ -441,31 +429,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day3_quiz.html
+++ b/day3_quiz.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="quiz-container">
             <div class="quiz-header">
                 <h1>第三天測驗：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</h1>
             </div>
@@ -183,31 +171,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day3_slides.html
+++ b/day3_slides.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="slide-container">
             <h1>第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</h1>
             
             <div class="slide-content">
@@ -359,31 +347,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day4.html
+++ b/day4.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="course-container">
             <aside class="sidebar">
                 <h3 class="sidebar-title">課程導覽</h3>
                 <ul class="sidebar-links">
@@ -322,31 +310,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day4_quiz.html
+++ b/day4_quiz.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="quiz-container">
             <div class="quiz-header">
                 <h1>第四天測驗：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</h1>
             </div>
@@ -182,31 +170,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day4_slides.html
+++ b/day4_slides.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="slide-container">
             <h1>第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</h1>
             
             <div class="slide-content">
@@ -253,31 +241,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day5.html
+++ b/day5.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="course-container">
             <aside class="sidebar">
                 <h3 class="sidebar-title">課程導覽</h3>
                 <ul class="sidebar-links">
@@ -305,31 +293,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day5_quiz.html
+++ b/day5_quiz.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="quiz-container">
             <div class="quiz-header">
                 <h1>第五天測驗：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</h1>
             </div>
@@ -184,31 +172,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/day5_slides.html
+++ b/day5_slides.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學 (Logic)入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <div class="container">
-        <div class="slide-container">
             <h1>第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</h1>
             
             <div class="slide-content">
@@ -276,31 +264,30 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學 (Logic)基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證 (Argument)與謬誤 (Fallacy)</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接 (Conjunction)詞 (Connective)與複合陳述句 (Statement) (Compound Statement)</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理 (Inference) (Deductive Reasoning)與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理 (Inference) (Inductive Reasoning)與批判性思考 (Critical Thinking)</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
-                <p data-en='<p data-en='<p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 Introduction to Logic Course. All rights reserved.'><p>&copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>copy; 2025 邏輯學 (Logic)入門課程. 保留所有權利。</p>
+                <p data-en="&copy; 2025 Introduction to Logic Course. All rights reserved.">&copy; 2025 邏輯學入門課程. 張渝江，保留所有權利。</p>
             </div>
         </div>
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -70,45 +70,45 @@
 
     <section class="course-overview">
         <div class="container">
-            <h2 class="section-title">課程概覽</h2>
+            <h2 class="section-title" data-en="Course Overview">課程概覽</h2>
             <div class="course-timeline">
                 <div class="timeline-item">
                     <div class="timeline-number">1</div>
                     <div class="timeline-content">
-                        <h3>邏輯學基礎與語言</h3>
-                        <p>了解邏輯學的定義與重要性，學習辨識陳述句與非陳述句，以及識別論證中的前提與結論。</p>
+                        <h3 data-en="Logic Basics and Language">邏輯學基礎與語言</h3>
+                        <p data-en="Learn the definition and importance of logic, identify statements and premises.">了解邏輯學的定義與重要性，學習辨識陳述句與非陳述句，以及識別論證中的前提與結論。</p>
                         <a href="day1.html" class="timeline-link">查看詳情</a>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-number">2</div>
                     <div class="timeline-content">
-                        <h3>論證與謬誤</h3>
-                        <p>理解有效論證與無效論證的區別，認識演繹推理與歸納推理的特點，以及學習辨識常見的邏輯謬誤。</p>
+                        <h3 data-en="Arguments and Fallacies">論證與謬誤</h3>
+                        <p data-en="Distinguish valid from invalid arguments, understand deductive and inductive reasoning, and identify common fallacies.">理解有效論證與無效論證的區別，認識演繹推理與歸納推理的特點，以及學習辨識常見的邏輯謬誤。</p>
                         <a href="day2.html" class="timeline-link">查看詳情</a>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-number">3</div>
                     <div class="timeline-content">
-                        <h3>邏輯連接詞與複合陳述句</h3>
-                        <p>學習邏輯連接詞及其在構建複合陳述句中的應用，理解條件句與雙條件句的邏輯結構。</p>
+                        <h3 data-en="Logical Connectives and Compound Statements">邏輯連接詞與複合陳述句</h3>
+                        <p data-en="Learn logical connectives and their role in constructing compound statements, including conditionals and biconditionals.">學習邏輯連接詞及其在構建複合陳述句中的應用，理解條件句與雙條件句的邏輯結構。</p>
                         <a href="day3.html" class="timeline-link">查看詳情</a>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-number">4</div>
                     <div class="timeline-content">
-                        <h3>演繹推理與邏輯規則</h3>
-                        <p>理解三段論的基本結構，學習基本邏輯符號的使用，掌握基本推理規則。</p>
+                        <h3 data-en="Deductive Reasoning and Rules">演繹推理與邏輯規則</h3>
+                        <p data-en="Understand syllogisms, basic logical symbols, and fundamental rules of inference.">理解三段論的基本結構，學習基本邏輯符號的使用，掌握基本推理規則。</p>
                         <a href="day4.html" class="timeline-link">查看詳情</a>
                     </div>
                 </div>
                 <div class="timeline-item">
                     <div class="timeline-number">5</div>
                     <div class="timeline-content">
-                        <h3>歸納推理與批判性思考</h3>
-                        <p>理解歸納推理的特點與應用，學習類比推理和因果關係推理的原理，綜合運用批判性思考技能。</p>
+                        <h3 data-en="Inductive Reasoning and Critical Thinking">歸納推理與批判性思考</h3>
+                        <p data-en="Study the nature of inductive reasoning, analogies, and causal reasoning, and apply critical thinking skills.">理解歸納推理的特點與應用，學習類比推理和因果關係推理的原理，綜合運用批判性思考技能。</p>
                         <a href="day5.html" class="timeline-link">查看詳情</a>
                     </div>
                 </div>
@@ -119,9 +119,9 @@
     <section class="cta">
         <div class="container">
             <div class="cta-content">
-                <h2>準備好開始學習邏輯學了嗎？</h2>
-                <p>邏輯學不僅是一門學科，更是一種思維方式。它能幫助你在學習和生活中做出更合理的判斷和決策。</p>
-                <a href="courses.html" class="btn">立即開始</a>
+                <h2 data-en="Ready to start learning logic?">準備好開始學習邏輯學了嗎？</h2>
+                <p data-en="Logic is more than a subject; it helps you make better decisions in life.">邏輯學不僅是一門學科，更是一種思維方式。它能幫助你在學習和生活中做出更合理的判斷和決策。</p>
+                <a href="courses.html" class="btn" data-en="Start Now">立即開始</a>
             </div>
         </div>
     </section>

--- a/terminology.html
+++ b/terminology.html
@@ -11,13 +11,13 @@
     <header>
         <div class="container">
             <nav class="navbar">
-                <a href="index.html" class="logo" data-en="Introduction to Logic" data-en="Introduction to Logic">邏輯學入門</a>
+                <a href="index.html" class="logo" data-en="Introduction to Logic">邏輯學入門</a>
                 <button class="mobile-menu-btn">☰</button>
                 <ul class="nav-links">
-                    <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                    <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                    <li><a href="terminology.html" data-en="Terminology" data-en="Terminology" class="active">術語表</a></li>
-                    <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                    <li><a href="index.html" data-en="Home">首頁</a></li>
+                    <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                    <li><a href="terminology.html" data-en="Terminology" class="active">術語表</a></li>
+                    <li><a href="about.html" data-en="About">關於課程</a></li>
                 </ul>
 <div class="lang-switcher">
 <select id="language-select">
@@ -25,18 +25,6 @@
 <option value="en">English</option>
 </select>
 </div>
-<div class="lang-switcher">
-<select id="language-select">
-<option value="zh">繁體中文</option>
-<option value="en">English</option>
-</select>
-</div>
-            </nav>
-        </div>
-    </header>
-
-    <section class="terminology">
-        <div class="container">
             <h1 class="section-title">邏輯學術語中英文對照表</h1>
             
             <div class="term-search">
@@ -183,20 +171,20 @@
                 <div class="footer-column">
                     <h3 data-en='Quick Links'>快速連結</h3>
                     <ul class="footer-links">
-                        <li><a href="index.html" data-en="Home" data-en="Home">首頁</a></li>
-                        <li><a href="courses.html" data-en="Courses" data-en="Courses">課程內容</a></li>
-                        <li><a href="terminology.html" data-en="Terminology" data-en="Terminology">術語表</a></li>
-                        <li><a href="about.html" data-en="About" data-en="About">關於課程</a></li>
+                        <li><a href="index.html" data-en="Home">首頁</a></li>
+                        <li><a href="courses.html" data-en="Courses">課程內容</a></li>
+                        <li><a href="terminology.html" data-en="Terminology">術語表</a></li>
+                        <li><a href="about.html" data-en="About">關於課程</a></li>
                     </ul>
                 </div>
                 <div class="footer-column">
                     <h3 data-en='Course Resources'>課程資源</h3>
                     <ul class="footer-links">
-                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language" data-en="Day 1: Logic Basics and Language">第一天：邏輯學基礎與語言</a></li>
-                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies" data-en="Day 2: Arguments and Fallacies">第二天：論證與謬誤</a></li>
-                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接詞與複合陳述句</a></li>
-                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理與邏輯規則</a></li>
-                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理與批判性思考</a></li>
+                        <li><a href="day1.html" data-en="Day 1: Logic Basics and Language">第一天：邏輯學基礎與語言</a></li>
+                        <li><a href="day2.html" data-en="Day 2: Arguments and Fallacies">第二天：論證與謬誤</a></li>
+                        <li><a href="day3.html" data-en="Day 3: Logical Connectives and Compound Statements">第三天：邏輯連接詞與複合陳述句</a></li>
+                        <li><a href="day4.html" data-en="Day 4: Deductive Reasoning and Rules">第四天：演繹推理與邏輯規則</a></li>
+                        <li><a href="day5.html" data-en="Day 5: Inductive Reasoning and Critical Thinking">第五天：歸納推理與批判性思考</a></li>
                     </ul>
                 </div>
             </div>
@@ -207,7 +195,6 @@
     </footer>
 
     <script src="js/main.js"></script>
-<script src="js/i18n.js"></script>
 <script src="js/i18n.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix corrupted copyright block
- add English translations for the index timeline and CTA
- remove duplicate language selector from pages
- keep a single i18n.js script tag per page

## Testing
- `npm test` *(fails: package.json missing)*